### PR TITLE
Mejora

### DIFF
--- a/js/OPT.js
+++ b/js/OPT.js
@@ -3,6 +3,7 @@ class MMU_OPT {
         console.log(`🔧 Inicializando MMU con ${ramSize} páginas en memoria.`);
         this.ramSize = ramSize;
         this.ram = new Map();
+        this.ptrCounter = 1;
         this.accessSequence = accessSequence; // Secuencia futura de accesos
         this.clock = 0;        // Tiempo total de simulación
         this.thrashing = 0;    // Tiempo perdido en fallos de páginas
@@ -33,7 +34,9 @@ class MMU_OPT {
     }
 
     allocatePage(pid, size) {
-        let ptr = `P${this.ram.size + 1}`; // Generamos un puntero para la nueva página
+        let ptr = `P${this.ptrCounter++}`; // NUEVO: Siempre crea P1, P2, P3… sin repetir
+        this.accessSequence.push(ptr); //NUEVO: PUNTEROS NUEVOS
+        
         let desperdicio = (Math.ceil(size / 4096) * 4096) - size; // Calcular fragmentación interna
         this.fragmentacion += desperdicio;
         console.log(`🛠️ Fragmentación interna en ${ptr}: ${desperdicio} bytes.`);
@@ -50,6 +53,11 @@ class MMU_OPT {
     }
 
     usePage(ptr) {
+
+
+        const index = this.accessSequence.indexOf(ptr);
+        if (index !== -1) this.accessSequence.splice(index, 1);
+
         if (this.ram.has(ptr)) {
             console.log(`🔵 HIT: Página ${ptr} está en RAM.`);
             this.clock += 1;


### PR DESCRIPTION
ptrCounter para generar nombres únicos como P1, P2, P3...

Antes podía repetirse el nombre de las páginas (ej. otra vez "P1").

Ahora cada página nueva tiene un nombre único usando un contador.

✅ Esto evita confusiones en los accesos y reemplazos.

Se actualiza la lista de accesos futuros (accessSequence)

Antes el algoritmo usaba una lista fija con nombres ("P1", "P2"...), pero no sabía cuándo ya se usaron.

🔄 Ahora, cuando se hace use(Px), esa página se quita de la lista de futuros.

✅ Así el algoritmo OPT puede decidir con más precisión cuál página expulsar.

Cuando creas una nueva página (allocatePage), también la agregas a los accesos futuros.

Eso es importante porque también debo considerar páginas nuevas en el futuro.